### PR TITLE
Accept a function for query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,27 @@ S.view
 The `.options()` configuration works as follows:
 
 - `query` (string, required)
-- `params` (object, optional) A [dot-notated string](https://www.npmjs.com/package/dlv) from the document object to a field, to use as variables in the query.
-- `useDraft` (bool, optional, default: `false`) When populating the `params` values, it will use the `published` version of the document by default.
+- `params` (object or function, optional) 
+  - Object: a [dot-notated string](https://www.npmjs.com/package/dlv) from the document object to a field, to use as variables in the query.
+  - Function: a function that receives the various displayed, draft, and published versions of the document, and returns an object of query parameters. Return null if the parameters cannot be resolved.
+- `useDraft` (bool, optional, default: `false`) When populating the `params` values, it will use the `published` version of the document by default. Not permitted if using a function for `params` as the function will determine which version of the document to use.
 - `debug` (bool, optional, default: `false`) In case of an error or the query returning no documents, setting to `true` will display the query and params that were used.
+
+
+## Resolving query parameters with a function
+This allows us to modify values from the current document, for example to list references to a draft document.
+```js
+const options = {
+  query: `*[!(_id in path("drafts.**")) && references($id)]`,
+  params: ({document}) => {
+    // references will never point to a draft ID, so extract the regular ID
+    const id = document.displayed._id?.replace('drafts.', '')
+    // if there's no ID yet, return null as we cannot resolve the parameters and the query will fail
+    if (!id) return null
+    return {id}
+  },
+}
+```
 
 ## Thanks!
 

--- a/src/Debug.tsx
+++ b/src/Debug.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {Code, Box, Label, Stack} from '@sanity/ui'
 
-export default function Debug({query, params}: {query: string; params: {[key: string]: string}}) {
+export default function Debug({query, params}: {query: string; params?: {[key: string]: string}}) {
   return (
     <>
       <Stack space={4}>
@@ -12,14 +12,16 @@ export default function Debug({query, params}: {query: string; params: {[key: st
           <Code>{query}</Code>
         </Box>
       </Stack>
-      <Stack space={4}>
-        <Box>
-          <Label>Params</Label>
-        </Box>
-        <Box>
-          <Code>{JSON.stringify(params)}</Code>
-        </Box>
-      </Stack>
+      {params && (
+        <Stack space={4}>
+          <Box>
+            <Label>Params</Label>
+          </Box>
+          <Box>
+            <Code>{JSON.stringify(params)}</Code>
+          </Box>
+        </Stack>
+      )}
     </>
   )
 }

--- a/src/DocumentsPane.tsx
+++ b/src/DocumentsPane.tsx
@@ -1,41 +1,38 @@
 import React from 'react'
-import delve from 'dlv'
 import {Stack} from '@sanity/ui'
-import {SanityDocument} from '@sanity/client'
 
 import Documents from './Documents'
 import Feedback from './Feedback'
 import Debug from './Debug'
-
-type DocumentsPaneOptions = {
-  query: string
-  params: {[key: string]: string}
-  debug: boolean
-  useDraft: boolean
-}
-
-type DocumentsPaneProps = {
-  document: SanityDocument
-  options: DocumentsPaneOptions
-}
+import {DocumentsPaneProps} from './types'
+import resolveParams from './resolveParams'
 
 export default function DocumentsPane(props: DocumentsPaneProps) {
-  const {document: sanityDocument, options} = props
+  const {document, options} = props
   const {query, params, useDraft, debug} = options
 
-  const doc = useDraft ? sanityDocument.displayed : sanityDocument.published
-  const {_rev} = doc ?? {}
-
-  const paramValues = Object.keys(params).reduce(
-    (acc, key) => ({...acc, [key]: delve(doc, params[key])}),
-    {}
-  )
-
-  if (!_rev) {
+  if (useDraft && typeof params === 'function') {
     return (
       <Stack padding={4} space={5}>
-        <Feedback>Document must be Published to have References</Feedback>
-        {debug && <Debug query={query} params={params} />}
+        <Feedback>
+          <code>useDraft</code> should not be <code>true</code> when supplying a function for
+          <code>params</code>
+        </Feedback>
+        {debug && <Debug query={query} />}
+      </Stack>
+    )
+  }
+
+  const paramValues = resolveParams({document, params, useDraft})
+
+  if (!paramValues) {
+    return (
+      <Stack padding={4} space={5}>
+        <Feedback>
+          Parameters for this query could not be resolved. This may mean the document does not yet
+          exist or is incomplete.
+        </Feedback>
+        {debug && <Debug query={query} />}
       </Stack>
     )
   }

--- a/src/DocumentsPane.tsx
+++ b/src/DocumentsPane.tsx
@@ -9,7 +9,7 @@ import resolveParams from './resolveParams'
 
 export default function DocumentsPane(props: DocumentsPaneProps) {
   const {document, options} = props
-  const {query, params, useDraft, debug} = options
+  const {query, params, useDraft = false, debug = false} = options
 
   if (useDraft && typeof params === 'function') {
     return (

--- a/src/resolveParams.ts
+++ b/src/resolveParams.ts
@@ -2,7 +2,7 @@ import {DocumentsPaneQueryParams, DocumentVersionsCollection} from './types'
 import delve from 'dlv'
 
 interface ResolveParamsOptions {
-  params: DocumentsPaneQueryParams
+  params?: DocumentsPaneQueryParams
   document: DocumentVersionsCollection
   useDraft: boolean
 }
@@ -23,6 +23,9 @@ export default function resolveParams(options: ResolveParamsOptions): ResolvePar
   // return null so that we can show the warning when the document hasn't been published yet
   // NB - not sure this works as intended, since drafts will have a _rev after the first mutation
   if (!_rev) return null
+
+  // params is optional
+  if (!params) return {}
 
   return Object.keys(params).reduce((acc, key) => ({...acc, [key]: delve(doc, params[key])}), {})
 }

--- a/src/resolveParams.ts
+++ b/src/resolveParams.ts
@@ -1,0 +1,28 @@
+import {DocumentsPaneQueryParams, DocumentVersionsCollection} from './types'
+import delve from 'dlv'
+
+interface ResolveParamsOptions {
+  params: DocumentsPaneQueryParams
+  document: DocumentVersionsCollection
+  useDraft: boolean
+}
+
+type ResolveParamsReturn = null | {[key: string]: string}
+
+export default function resolveParams(options: ResolveParamsOptions): ResolveParamsReturn {
+  const {params, document, useDraft} = options
+
+  if (typeof params == 'function') {
+    return params({document})
+  }
+
+  // legacy useDraft behaviour
+  const doc = useDraft ? document.displayed : document.published
+  const {_rev} = doc ?? {}
+
+  // return null so that we can show the warning when the document hasn't been published yet
+  // NB - not sure this works as intended, since drafts will have a _rev after the first mutation
+  if (!_rev) return null
+
+  return Object.keys(params).reduce((acc, key) => ({...acc, [key]: delve(doc, params[key])}), {})
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,23 @@
+import {SanityDocument} from '@sanity/client'
+
+export interface DocumentVersionsCollection {
+  displayed: SanityDocument
+  published: SanityDocument
+  draft: SanityDocument
+  historical: SanityDocument
+}
+
+// eslint-disable-next-line prettier/prettier
+export type DocumentsPaneQueryParams = (params: {document: DocumentVersionsCollection}) => ({[key: string]: string} | null) | {[key: string]: string}
+
+export type DocumentsPaneOptions = {
+  query: string
+  params: DocumentsPaneQueryParams
+  debug: boolean
+  useDraft: boolean
+}
+
+export type DocumentsPaneProps = {
+  document: DocumentVersionsCollection
+  options: DocumentsPaneOptions
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,9 +12,9 @@ export type DocumentsPaneQueryParams = (params: {document: DocumentVersionsColle
 
 export type DocumentsPaneOptions = {
   query: string
-  params: DocumentsPaneQueryParams
-  debug: boolean
-  useDraft: boolean
+  params?: DocumentsPaneQueryParams
+  debug?: boolean
+  useDraft?: boolean
 }
 
 export type DocumentsPaneProps = {


### PR DESCRIPTION
Allows passing a function instead of an object to resolve parameters. Allows the user to define logic for using `displayed`, `draft`, or `published` versions of the document to define the query parameters.

Updates the error message when parameters cannot be resolved.

Also
* Clarifies a couple types
* Ensures that optional options are optional

Closes #9 