### PR TITLE
Feat: create new documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ sanity install documents-pane
 
 This plugin is designed to be used as a [Component inside of a View](https://www.sanity.io/docs/structure-builder-reference#c0c8284844b7).
 
-The example below illustrates using the current Document being used to query for all Documents that reference it.
+The example below illustrates using the current Document being used to query for all published documents that reference it.
 
 ```js
 // ./src/deskStructure.js
@@ -25,33 +25,60 @@ S.view
   .options({
     query: `*[!(_id in path("drafts.**")) && references($id)]`,
     params: {id: `_id`},
-    useDraft: false,
-    debug: true,
   })
   .title('Incoming References')
 ```
 
 The `.options()` configuration works as follows:
 
-- `query` (string, required)
+- `query` (string, required) A string defining the entire GROQ query that will select documents to list.
 - `params` (object or function, optional) 
   - Object: a [dot-notated string](https://www.npmjs.com/package/dlv) from the document object to a field, to use as variables in the query.
   - Function: a function that receives the various displayed, draft, and published versions of the document, and returns an object of query parameters. Return null if the parameters cannot be resolved.
 - `useDraft` (bool, optional, default: `false`) When populating the `params` values, it will use the `published` version of the document by default. Not permitted if using a function for `params` as the function will determine which version of the document to use.
 - `debug` (bool, optional, default: `false`) In case of an error or the query returning no documents, setting to `true` will display the query and params that were used.
+- `initialValueTemplates` (function, optional) A function that receives the various displayed, draft, and published versions of the document, and returns a list of initial value templates. These will be used to define buttons at the top of the list so users can create new related documents.
 
 
-## Resolving query parameters with a function
-This allows us to modify values from the current document, for example to list references to a draft document.
+## Resolving query parameters with a function and providing initial value templates
+Providing a function for `params` allows us to modify values from the current document, for example to list references to a draft document. Providing a function for the `initialValueTemplates` option allows us to determine which buttons to show and what parameters will be used for the new document.
 ```js
 const options = {
-  query: `*[!(_id in path("drafts.**")) && references($id)]`,
+  query: `*[_type=="post" && author._ref == $id]`,
   params: ({document}) => {
     // references will never point to a draft ID, so extract the regular ID
     const id = document.displayed._id?.replace('drafts.', '')
     // if there's no ID yet, return null as we cannot resolve the parameters and the query will fail
     if (!id) return null
     return {id}
+  },
+  initialValueTemplates: ({document}) => {
+    const templates = []
+
+    // references must point to a non-draft ID, so if using the ID in the template, 
+    // be sure it doesn't start with `drafts.`
+    const id = document?.displayed?._id.replace('drafts.', '')
+    const name = document?.displayed?.name || 'author'
+
+    if (id) {
+      templates.push({
+        // the name of the schema type that should be created (required)
+        type: 'post',
+        // the title that should appear on the button - we can customize it (required)
+        title: `New post by ${name}`,
+        // the name of the template that should be used (optional)
+        template: 'postWithAuthor',
+        // values for parameters that can be passed to the template referenced above (optional)
+        params: {
+          authorId: id,
+        },
+      })
+
+      // we could push more templates if needed.
+    }
+
+    // must always return a list, even if empty
+    return templates
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -34,9 +34,27 @@ S.view
 The `.options()` configuration works as follows:
 
 - `query` (string, required)
-- `params` (object, optional) A [dot-notated string](https://www.npmjs.com/package/dlv) from the document object to a field, to use as variables in the query.
-- `useDraft` (bool, optional, default: `false`) When populating the `params` values, it will use the `published` version of the document by default.
+- `params` (object or function, optional) 
+  - Object: a [dot-notated string](https://www.npmjs.com/package/dlv) from the document object to a field, to use as variables in the query.
+  - Function: a function that receives the various displayed, draft, and published versions of the document, and returns an object of query parameters. Return null if the parameters cannot be resolved.
+- `useDraft` (bool, optional, default: `false`) When populating the `params` values, it will use the `published` version of the document by default. Not permitted if using a function for `params` as the function will determine which version of the document to use.
 - `debug` (bool, optional, default: `false`) In case of an error or the query returning no documents, setting to `true` will display the query and params that were used.
+
+
+## Resolving query parameters with a function
+This allows us to modify values from the current document, for example to list references to a draft document.
+```js
+const options = {
+  query: `*[!(_id in path("drafts.**")) && references($id)]`,
+  params: ({document}) => {
+    // references will never point to a draft ID, so extract the regular ID
+    const id = document.displayed._id?.replace('drafts.', '')
+    // if there's no ID yet, return null as we cannot resolve the parameters and the query will fail
+    if (!id) return null
+    return {id}
+  },
+}
+```
 
 ## Thanks!
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "dependencies": {
-    "@sanity/ui": "^0.37.12",
+    "@sanity/icons": "^1.3.4",
+    "@sanity/ui": "^0.38.0",
     "dlv": "^1.1.3",
     "react-fast-compare": "^3.2.0",
     "rxjs": "^6.5.6"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "peerDependencies": {
     "@sanity/base": "^2.30.1",
     "@sanity/desk-tool": "^2.30.1",
+    "@sanity/uuid": "^3.0.1",
     "@sanity/util": "^2.29.5",
     "react": "^16.0.0 || ^17.0.0"
   },

--- a/src/Debug.tsx
+++ b/src/Debug.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {Code, Box, Label, Stack} from '@sanity/ui'
 
-export default function Debug({query, params}: {query: string; params: {[key: string]: string}}) {
+export default function Debug({query, params}: {query: string; params?: {[key: string]: string}}) {
   return (
     <>
       <Stack space={4}>
@@ -12,14 +12,16 @@ export default function Debug({query, params}: {query: string; params: {[key: st
           <Code>{query}</Code>
         </Box>
       </Stack>
-      <Stack space={4}>
-        <Box>
-          <Label>Params</Label>
-        </Box>
-        <Box>
-          <Code>{JSON.stringify(params)}</Code>
-        </Box>
-      </Stack>
+      {params && (
+        <Stack space={4}>
+          <Box>
+            <Label>Params</Label>
+          </Box>
+          <Box>
+            <Code>{JSON.stringify(params)}</Code>
+          </Box>
+        </Stack>
+      )}
     </>
   )
 }

--- a/src/Documents.tsx
+++ b/src/Documents.tsx
@@ -8,15 +8,18 @@ import schema from 'part:@sanity/base/schema'
 import Debug from './Debug'
 import Feedback from './Feedback'
 import useListeningQuery from './hooks/useListeningQuery'
+import { DocumentsPaneInitialValueTemplate } from './types'
+import NewDocument from './NewDocument'
 
 type DocumentsProps = {
   query: string
   params: {[key: string]: string}
   debug: boolean
+  initialValueTemplates: DocumentsPaneInitialValueTemplate[]
 }
 
 export default function Documents(props: DocumentsProps) {
-  const {query, params, debug} = props
+  const {query, params, debug, initialValueTemplates} = props
   const {routerPanesState, groupIndex, handleEditReference} = usePaneRouter()
 
   const {loading, error, data} = useListeningQuery(query, params)
@@ -60,6 +63,7 @@ export default function Documents(props: DocumentsProps) {
   if (!data?.length) {
     return (
       <Stack padding={4} space={5}>
+        <NewDocument initialValueTemplates={initialValueTemplates} />
         <Feedback>No Documents found</Feedback>
         {debug && <Debug query={query} params={params} />}
       </Stack>
@@ -68,6 +72,7 @@ export default function Documents(props: DocumentsProps) {
 
   return (
     <Stack padding={2} space={1}>
+      <NewDocument initialValueTemplates={initialValueTemplates} />
       {data.map((doc) => (
         <Button
           key={doc._id}

--- a/src/Documents.tsx
+++ b/src/Documents.tsx
@@ -8,7 +8,7 @@ import schema from 'part:@sanity/base/schema'
 import Debug from './Debug'
 import Feedback from './Feedback'
 import useListeningQuery from './hooks/useListeningQuery'
-import { DocumentsPaneInitialValueTemplate } from './types'
+import {DocumentsPaneInitialValueTemplate} from './types'
 import NewDocument from './NewDocument'
 
 type DocumentsProps = {
@@ -62,27 +62,31 @@ export default function Documents(props: DocumentsProps) {
 
   if (!data?.length) {
     return (
-      <Stack padding={4} space={5}>
+      <>
         <NewDocument initialValueTemplates={initialValueTemplates} />
-        <Feedback>No Documents found</Feedback>
-        {debug && <Debug query={query} params={params} />}
-      </Stack>
+        <Stack padding={4} space={5}>
+          <Feedback>No Documents found</Feedback>
+          {debug && <Debug query={query} params={params} />}
+        </Stack>
+      </>
     )
   }
 
   return (
-    <Stack padding={2} space={1}>
+    <>
       <NewDocument initialValueTemplates={initialValueTemplates} />
-      {data.map((doc) => (
-        <Button
-          key={doc._id}
-          onClick={() => handleClick(doc._id, doc._type)}
-          padding={2}
-          mode="bleed"
-        >
-          <Preview value={doc} type={schema.get(doc._type)} />
-        </Button>
-      ))}
-    </Stack>
+      <Stack padding={2} space={1}>
+        {data.map((doc) => (
+          <Button
+            key={doc._id}
+            onClick={() => handleClick(doc._id, doc._type)}
+            padding={2}
+            mode="bleed"
+          >
+            <Preview value={doc} type={schema.get(doc._type)} />
+          </Button>
+        ))}
+      </Stack>
+    </>
   )
 }

--- a/src/DocumentsPane.tsx
+++ b/src/DocumentsPane.tsx
@@ -1,41 +1,38 @@
 import React from 'react'
-import delve from 'dlv'
 import {Stack} from '@sanity/ui'
-import {SanityDocument} from '@sanity/client'
 
 import Documents from './Documents'
 import Feedback from './Feedback'
 import Debug from './Debug'
-
-type DocumentsPaneOptions = {
-  query: string
-  params: {[key: string]: string}
-  debug: boolean
-  useDraft: boolean
-}
-
-type DocumentsPaneProps = {
-  document: SanityDocument
-  options: DocumentsPaneOptions
-}
+import {DocumentsPaneProps} from './types'
+import resolveParams from './resolveParams'
 
 export default function DocumentsPane(props: DocumentsPaneProps) {
-  const {document: sanityDocument, options} = props
+  const {document, options} = props
   const {query, params, useDraft, debug} = options
 
-  const doc = useDraft ? sanityDocument.displayed : sanityDocument.published
-  const {_rev} = doc ?? {}
-
-  const paramValues = Object.keys(params).reduce(
-    (acc, key) => ({...acc, [key]: delve(doc, params[key])}),
-    {}
-  )
-
-  if (!_rev) {
+  if (useDraft && typeof params === 'function') {
     return (
       <Stack padding={4} space={5}>
-        <Feedback>Document must be Published to have References</Feedback>
-        {debug && <Debug query={query} params={params} />}
+        <Feedback>
+          <code>useDraft</code> should not be <code>true</code> when supplying a function for
+          <code>params</code>
+        </Feedback>
+        {debug && <Debug query={query} />}
+      </Stack>
+    )
+  }
+
+  const paramValues = resolveParams({document, params, useDraft})
+
+  if (!paramValues) {
+    return (
+      <Stack padding={4} space={5}>
+        <Feedback>
+          Parameters for this query could not be resolved. This may mean the document does not yet
+          exist or is incomplete.
+        </Feedback>
+        {debug && <Debug query={query} />}
       </Stack>
     )
   }

--- a/src/DocumentsPane.tsx
+++ b/src/DocumentsPane.tsx
@@ -9,7 +9,7 @@ import resolveParams from './resolveParams'
 
 export default function DocumentsPane(props: DocumentsPaneProps) {
   const {document, options} = props
-  const {query, params, useDraft, debug} = options
+  const {query, params, useDraft = false, debug = false} = options
 
   if (useDraft && typeof params === 'function') {
     return (

--- a/src/DocumentsPane.tsx
+++ b/src/DocumentsPane.tsx
@@ -6,10 +6,17 @@ import Feedback from './Feedback'
 import Debug from './Debug'
 import {DocumentsPaneProps} from './types'
 import resolveParams from './resolveParams'
+import resolveInitialValueTemplates from './resolveInitialValueTemplates'
 
 export default function DocumentsPane(props: DocumentsPaneProps) {
   const {document, options} = props
-  const {query, params, useDraft = false, debug = false} = options
+  const {
+    query,
+    params,
+    useDraft = false,
+    debug = false,
+    initialValueTemplates: initialValueTemplatesResolver,
+  } = options
 
   if (useDraft && typeof params === 'function') {
     return (
@@ -25,6 +32,11 @@ export default function DocumentsPane(props: DocumentsPaneProps) {
 
   const paramValues = resolveParams({document, params, useDraft})
 
+  const initialValueTemplates = resolveInitialValueTemplates({
+    resolver: initialValueTemplatesResolver,
+    document,
+  })
+
   if (!paramValues) {
     return (
       <Stack padding={4} space={5}>
@@ -37,5 +49,12 @@ export default function DocumentsPane(props: DocumentsPaneProps) {
     )
   }
 
-  return <Documents query={query} params={paramValues} debug={debug} />
+  return (
+    <Documents
+      query={query}
+      params={paramValues}
+      debug={debug}
+      initialValueTemplates={initialValueTemplates}
+    />
+  )
 }

--- a/src/NewDocument.tsx
+++ b/src/NewDocument.tsx
@@ -1,0 +1,52 @@
+import {Button, Flex} from '@sanity/ui'
+import React, {forwardRef, useCallback} from 'react'
+import {DocumentsPaneInitialValueTemplate} from './types'
+import {ComposeIcon} from '@sanity/icons'
+import {usePaneRouter} from '@sanity/desk-tool'
+
+interface NewDocumentProps {
+  initialValueTemplates: DocumentsPaneInitialValueTemplate[]
+}
+
+function newId() {
+  return Math.random().toString().replace('.', '')
+}
+
+export default function NewDocument(props: NewDocumentProps) {
+  const {initialValueTemplates = []} = props
+  const {ChildLink, ReferenceChildLink, handleEditReference} = usePaneRouter()
+
+  const handleNewDocument = useCallback(
+    (template: DocumentsPaneInitialValueTemplate) => {
+      handleEditReference({
+        parentRefPath: [],
+        id: newId(),
+        type: template.type,
+        template: {
+          id: template.template || template.type,
+          params: template.params,
+        },
+      })
+    },
+    [handleEditReference]
+  )
+
+  return (
+    <Flex justify="flex-end">
+      {initialValueTemplates.map((template) => {
+        return (
+          <ReferenceChildLink
+            documentId={newId()}
+            documentType={template.type}
+            template={{id: template.template, params: template.params}}
+            parentRefPath={[]}
+            key={`${template.type}-${template.template}`}
+            style={{textDecoration: 'none'}}
+          >
+            <Button icon={<ComposeIcon />} text={template.title} mode="ghost" as="span" />
+          </ReferenceChildLink>
+        )
+      })}
+    </Flex>
+  )
+}

--- a/src/NewDocument.tsx
+++ b/src/NewDocument.tsx
@@ -1,5 +1,5 @@
-import {Button, Flex} from '@sanity/ui'
-import React, {forwardRef, useCallback} from 'react'
+import {Button, Card, Flex} from '@sanity/ui'
+import React from 'react'
 import {DocumentsPaneInitialValueTemplate} from './types'
 import {ComposeIcon} from '@sanity/icons'
 import {usePaneRouter} from '@sanity/desk-tool'
@@ -14,39 +14,28 @@ function newId() {
 
 export default function NewDocument(props: NewDocumentProps) {
   const {initialValueTemplates = []} = props
-  const {ChildLink, ReferenceChildLink, handleEditReference} = usePaneRouter()
+  const {ReferenceChildLink} = usePaneRouter()
 
-  const handleNewDocument = useCallback(
-    (template: DocumentsPaneInitialValueTemplate) => {
-      handleEditReference({
-        parentRefPath: [],
-        id: newId(),
-        type: template.type,
-        template: {
-          id: template.template || template.type,
-          params: template.params,
-        },
-      })
-    },
-    [handleEditReference]
-  )
+  if (!initialValueTemplates.length) return null
 
   return (
-    <Flex justify="flex-end">
-      {initialValueTemplates.map((template) => {
-        return (
-          <ReferenceChildLink
-            documentId={newId()}
-            documentType={template.type}
-            template={{id: template.template, params: template.params}}
-            parentRefPath={[]}
-            key={`${template.type}-${template.template}`}
-            style={{textDecoration: 'none'}}
-          >
-            <Button icon={<ComposeIcon />} text={template.title} mode="ghost" as="span" />
-          </ReferenceChildLink>
-        )
-      })}
-    </Flex>
+    <Card borderBottom={true} padding={2}>
+      <Flex justify="flex-end" gap={1}>
+        {initialValueTemplates.map((template) => {
+          return (
+            <ReferenceChildLink
+              documentId={newId()}
+              documentType={template.type}
+              template={{id: template.template, params: template.params}}
+              parentRefPath={[]}
+              key={`${template.type}-${template.template}`}
+              style={{textDecoration: 'none'}}
+            >
+              <Button icon={<ComposeIcon />} text={template.title} mode="bleed" as="span" />
+            </ReferenceChildLink>
+          )
+        })}
+      </Flex>
+    </Card>
   )
 }

--- a/src/NewDocument.tsx
+++ b/src/NewDocument.tsx
@@ -3,13 +3,10 @@ import React from 'react'
 import {DocumentsPaneInitialValueTemplate} from './types'
 import {ComposeIcon} from '@sanity/icons'
 import {usePaneRouter} from '@sanity/desk-tool'
+import {uuid} from "@sanity/uuid"
 
 interface NewDocumentProps {
   initialValueTemplates: DocumentsPaneInitialValueTemplate[]
-}
-
-function newId() {
-  return Math.random().toString().replace('.', '')
 }
 
 export default function NewDocument(props: NewDocumentProps) {
@@ -24,7 +21,7 @@ export default function NewDocument(props: NewDocumentProps) {
         {initialValueTemplates.map((template) => {
           return (
             <ReferenceChildLink
-              documentId={newId()}
+              documentId={uuid()}
               documentType={template.type}
               template={{id: template.template, params: template.params}}
               parentRefPath={[]}

--- a/src/resolveInitialValueTemplates.ts
+++ b/src/resolveInitialValueTemplates.ts
@@ -1,0 +1,20 @@
+import {
+  DocumentsPaneInitialValueTemplate,
+  DocumentsPaneInitialValueTemplateResolver,
+  DocumentVersionsCollection,
+} from './types'
+
+interface ResolveInitialValueTemplatesOptions {
+  resolver: DocumentsPaneInitialValueTemplateResolver | undefined
+  document: DocumentVersionsCollection
+}
+
+export default function resolveInitialValueTemplates(
+  options: ResolveInitialValueTemplatesOptions
+): DocumentsPaneInitialValueTemplate[] {
+  const {resolver, document} = options || {}
+
+  if (!resolver) return []
+
+  return resolver({document})
+}

--- a/src/resolveParams.ts
+++ b/src/resolveParams.ts
@@ -2,7 +2,7 @@ import {DocumentsPaneQueryParams, DocumentVersionsCollection} from './types'
 import delve from 'dlv'
 
 interface ResolveParamsOptions {
-  params: DocumentsPaneQueryParams
+  params?: DocumentsPaneQueryParams
   document: DocumentVersionsCollection
   useDraft: boolean
 }
@@ -23,6 +23,9 @@ export default function resolveParams(options: ResolveParamsOptions): ResolvePar
   // return null so that we can show the warning when the document hasn't been published yet
   // NB - not sure this works as intended, since drafts will have a _rev after the first mutation
   if (!_rev) return null
+
+  // params is optional
+  if (!params) return {}
 
   return Object.keys(params).reduce((acc, key) => ({...acc, [key]: delve(doc, params[key])}), {})
 }

--- a/src/resolveParams.ts
+++ b/src/resolveParams.ts
@@ -1,0 +1,28 @@
+import {DocumentsPaneQueryParams, DocumentVersionsCollection} from './types'
+import delve from 'dlv'
+
+interface ResolveParamsOptions {
+  params: DocumentsPaneQueryParams
+  document: DocumentVersionsCollection
+  useDraft: boolean
+}
+
+type ResolveParamsReturn = null | {[key: string]: string}
+
+export default function resolveParams(options: ResolveParamsOptions): ResolveParamsReturn {
+  const {params, document, useDraft} = options
+
+  if (typeof params == 'function') {
+    return params({document})
+  }
+
+  // legacy useDraft behaviour
+  const doc = useDraft ? document.displayed : document.published
+  const {_rev} = doc ?? {}
+
+  // return null so that we can show the warning when the document hasn't been published yet
+  // NB - not sure this works as intended, since drafts will have a _rev after the first mutation
+  if (!_rev) return null
+
+  return Object.keys(params).reduce((acc, key) => ({...acc, [key]: delve(doc, params[key])}), {})
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,11 +10,22 @@ export interface DocumentVersionsCollection {
 // eslint-disable-next-line prettier/prettier
 export type DocumentsPaneQueryParams = (params: {document: DocumentVersionsCollection}) => ({[key: string]: string} | null) | {[key: string]: string}
 
+export interface DocumentsPaneInitialValueTemplate {
+  type: string
+  template?: string
+  params?: {[key: string]: any}
+  title: string
+}
+
+// eslint-disable-next-line prettier/prettier
+export type DocumentsPaneInitialValueTemplateResolver = (params: {document: DocumentVersionsCollection}) => DocumentsPaneInitialValueTemplate[]
+
 export type DocumentsPaneOptions = {
   query: string
   params?: DocumentsPaneQueryParams
   debug?: boolean
   useDraft?: boolean
+  initialValueTemplates?: DocumentsPaneInitialValueTemplateResolver
 }
 
 export type DocumentsPaneProps = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,23 @@
+import {SanityDocument} from '@sanity/client'
+
+export interface DocumentVersionsCollection {
+  displayed: SanityDocument
+  published: SanityDocument
+  draft: SanityDocument
+  historical: SanityDocument
+}
+
+// eslint-disable-next-line prettier/prettier
+export type DocumentsPaneQueryParams = (params: {document: DocumentVersionsCollection}) => ({[key: string]: string} | null) | {[key: string]: string}
+
+export type DocumentsPaneOptions = {
+  query: string
+  params: DocumentsPaneQueryParams
+  debug: boolean
+  useDraft: boolean
+}
+
+export type DocumentsPaneProps = {
+  document: DocumentVersionsCollection
+  options: DocumentsPaneOptions
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,9 +12,9 @@ export type DocumentsPaneQueryParams = (params: {document: DocumentVersionsColle
 
 export type DocumentsPaneOptions = {
   query: string
-  params: DocumentsPaneQueryParams
-  debug: boolean
-  useDraft: boolean
+  params?: DocumentsPaneQueryParams
+  debug?: boolean
+  useDraft?: boolean
 }
 
 export type DocumentsPaneProps = {


### PR DESCRIPTION
Builds on #10 

Adds ability to define a list of initial value templates that will cause "new document" buttons to be rendered in the pane.
The developer can provide a function for the `initialValueTemplates` option that will return a list of initial value template configurations.

To review:
* UI
* Interface - do the `initialValueTemplates` function and the template configuration objects make sense? Do naming conventions follow the rest of the Sanity ecosystem?
